### PR TITLE
Working settings for production

### DIFF
--- a/back/datarcBack/datarcBack/settings.py
+++ b/back/datarcBack/datarcBack/settings.py
@@ -12,13 +12,14 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib import Path
 import environ
+import os.path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Setting up environment file
 env = environ.Env()
-environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
+environ.Env.read_env(os.path.join(BASE_DIR, '.env')) # .env file not used in production, environ loads system environnement variables instead
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
@@ -83,11 +84,11 @@ WSGI_APPLICATION = 'datarcBack.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': env('DB_NAME'),
-        'HOST': env('DB_HOST'),
-        'PORT': env('DB_PORT'),
-        'USER': env('DB_USER'),
-        'PASSWORD': env('DB_PASSWORD'),
+        'NAME': env('DATABASE_NAME'),
+        'HOST': env('MYSQL_HOST'),
+        'PORT': env('MYSQL_PORT'),
+        'USER': env('GROUPNAME'),
+        'PASSWORD': env('PASSWORD'),
         'OPTIONS': {'ssl_mode': 'DISABLED'},
     }
 }


### PR DESCRIPTION
What I did on the server that is not in the code :
- In production, we arent using .env, but system environment variables that are located in `/etc/container_environment`.
  In this folder, there are files containing a value. The name of the file is the name of the variable, and its content is the value of the variable.
- I corrected the virtual environment of django that was in `current`. It now is in the `shared` folder that won't change with every push.